### PR TITLE
Fix Danish translation error

### DIFF
--- a/translations/da/retakes_breaker.phrases.txt
+++ b/translations/da/retakes_breaker.phrases.txt
@@ -6,6 +6,6 @@
     }
     "Open"
     {
-        "da"            "Alle døre er blevet åbnet."s
+        "da"            "Alle døre er blevet åbnet."
     }
 }


### PR DESCRIPTION
I see errors in the logs:
```
L 05/13/2021 - 22:40:19: SourceMod error session started
L 05/13/2021 - 22:40:19: Info (map "de_ancient") (file "/home/csgo/serverfiles/csgo/addons/sourcemod/logs/errors_20210513.log")
L 05/13/2021 - 22:40:19: [SM] Fatal error encountered parsing translation file "da/retakes_breaker.phrases.txt"
L 05/13/2021 - 22:40:19: [SM] Error (line 9, column 56): Line contained too many invalid tokens
```